### PR TITLE
Support new particle data

### DIFF
--- a/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
+++ b/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
@@ -131,9 +131,15 @@ public class TrailGUI
                         {
                             trailTypes.put(trailTypeSection.getName(), new ItemTrail(trailTypeSection));
                         }
-                        else if (trailTypeSection.getString("type").equalsIgnoreCase("BLOCK_CRACK"))
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("BLOCK_CRACK")
+                                || trailTypeSection.getString("type").equalsIgnoreCase("BLOCK_DUST")
+                                || trailTypeSection.getString("type").equalsIgnoreCase("FALLING_DUST"))
                         {
                             trailTypes.put(trailTypeSection.getName(), new BlockTrail(trailTypeSection));
+                        }
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("REDSTONE"))
+                        {
+                            trailTypes.put(trailTypeSection.getName(), new RedstoneTrail(trailTypeSection));
                         }
                         else if (trailTypeSection.getBoolean("is_effect", false))
                         {

--- a/src/main/java/ca/jamiesinn/trailgui/trails/BlockTrail.java
+++ b/src/main/java/ca/jamiesinn/trailgui/trails/BlockTrail.java
@@ -1,20 +1,18 @@
 package ca.jamiesinn.trailgui.trails;
 
 import org.bukkit.Particle;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.material.MaterialData;
 
 public class BlockTrail extends Trail
 {
-    private MaterialData blockData;
-    private byte itemData;
+    private BlockData blockData;
 
     public BlockTrail(ConfigurationSection config)
     {
         super(config);
-        itemData = (byte)config.getInt("data", 0);
-        blockData = new MaterialData(itemType, itemData);
+        blockData = itemType.createBlockData();
         loadType(config.getString("type"));
     }
 

--- a/src/main/java/ca/jamiesinn/trailgui/trails/RedstoneTrail.java
+++ b/src/main/java/ca/jamiesinn/trailgui/trails/RedstoneTrail.java
@@ -1,18 +1,20 @@
 package ca.jamiesinn.trailgui.trails;
 
+import org.bukkit.Color;
 import org.bukkit.Particle;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
-public class ItemTrail extends Trail
+public class RedstoneTrail extends Trail
 {
-    private ItemStack data;
+    private Particle.DustOptions dustOptions;
 
-    public ItemTrail(ConfigurationSection config)
+    public RedstoneTrail(ConfigurationSection config)
     {
         super(config);
-        data = new ItemStack(itemType, 1);
+        Color color = config.getColor("dustColor", Color.RED);
+        float size = (float) config.getDouble("dustSize", 1);
+        dustOptions = new Particle.DustOptions(color, size);
         loadType(config.getString("type"));
     }
 
@@ -25,11 +27,7 @@ public class ItemTrail extends Trail
     @Override
     public void justDisplay(Player player)
     {
-        if (type == null)
-        {
-            return;
-        }
         if(!displayEvent(getName(), getDisplayLocation(), getAmount(), cooldown, getSpeed(), getRange(), type).isCancelled())
-            player.getWorld().spawnParticle(type, player.getLocation().add(0.0D, displayLocation, 0.0D), amount, 0,0,0, speed, data);
+            player.getWorld().spawnParticle(type, player.getLocation().add(0.0D, displayLocation, 0.0D), amount, 0,0,0, speed, dustOptions);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -505,6 +505,14 @@ trails:
     order: 17
     #The items type.
     itemType: redstone
+    #Color of the dust.
+    dustColor:
+      ==: Color
+      RED: 0xFF
+      GREEN: 0x00
+      BLUE: 0x00
+    #Size of the dust.
+    dustSize: 1
     #The items name.
     itemName: "&6RedDust"
     #Whether or not the lore is enabled.
@@ -528,6 +536,14 @@ trails:
     order: 18
     #The items type.
     itemType: glowstone_dust
+    #Color of the dust.
+    dustColor:
+      ==: Color
+      RED: 0xFF
+      GREEN: 0xA5
+      BLUE: 0x00
+    #Size of the dust.
+    dustSize: 1
     #The items name.
     itemName: "&6ColoredRedDust"
     #Whether or not the lore is enabled.
@@ -792,6 +808,14 @@ trails:
     order: 31
     #The items type.
     itemType: coal
+    #Color of the dust.
+    dustColor:
+      ==: Color
+      RED: 0x00
+      GREEN: 0x00
+      BLUE: 0x00
+    #Size of the dust.
+    dustSize: 3
     #The items name.
     itemName: "&6BlackDust"
     #Whether or not the lore is enabled.
@@ -929,7 +953,7 @@ trails:
     #The inventory slot the item is put in.
     order: 38
     #The items type.
-    itemType: gunpowder
+    itemType: gravel
     #The items name.
     itemName: "&6FallingDust"
     #Whether or not the lore is enabled.

--- a/src/test/java/MaterialsTest.java
+++ b/src/test/java/MaterialsTest.java
@@ -55,9 +55,15 @@ public class MaterialsTest
                         {
                             trail = new ItemTrail(trailTypeSection);
                         }
-                        else if (trailTypeSection.getString("type").equalsIgnoreCase("BLOCK_CRACK"))
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("BLOCK_CRACK")
+                                || trailTypeSection.getString("type").equalsIgnoreCase("BLOCK_DUST")
+                                || trailTypeSection.getString("type").equalsIgnoreCase("FALLING_DUST"))
                         {
                             trail = new BlockTrail(trailTypeSection);
+                        }
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("REDSTONE"))
+                        {
+                            trail = new RedstoneTrail(trailTypeSection);
                         }
                         else if (trailTypeSection.getBoolean("is_effect", false))
                         {

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -505,6 +505,14 @@ trails:
     order: 17
     #The items type.
     itemType: redstone
+    #Color of the dust.
+    dustColor:
+      ==: Color
+      RED: 0xFF
+      GREEN: 0x00
+      BLUE: 0x00
+    #Size of the dust.
+    dustSize: 1
     #The items name.
     itemName: "&6RedDust"
     #Whether or not the lore is enabled.
@@ -528,6 +536,14 @@ trails:
     order: 18
     #The items type.
     itemType: glowstone_dust
+    #Color of the dust.
+    dustColor:
+      ==: Color
+      RED: 0xFF
+      GREEN: 0xA5
+      BLUE: 0x00
+    #Size of the dust.
+    dustSize: 1
     #The items name.
     itemName: "&6ColoredRedDust"
     #Whether or not the lore is enabled.
@@ -792,6 +808,14 @@ trails:
     order: 31
     #The items type.
     itemType: coal
+    #Color of the dust.
+    dustColor:
+      ==: Color
+      RED: 0x00
+      GREEN: 0x00
+      BLUE: 0x00
+    #Size of the dust.
+    dustSize: 3
     #The items name.
     itemName: "&6BlackDust"
     #Whether or not the lore is enabled.
@@ -929,7 +953,7 @@ trails:
     #The inventory slot the item is put in.
     order: 38
     #The items type.
-    itemType: gunpowder
+    itemType: gravel
     #The items name.
     itemName: "&6FallingDust"
     #Whether or not the lore is enabled.


### PR DESCRIPTION
While testing the plugin in 1.14.4, I found that the following default trails result in errors in the console: RedDust, ColoredRedDust, Melon, BlackDust and FallingDust. Here is an example of such an error (truncated by a lot): 

> Caused by: java.lang.IllegalArgumentException: Particle REDSTONE requires data, null provided

The particle types of these trails are REDSTONE, BLOCK_CRACK and FALLING_DUST. These errors are caused by the use of out-dated data objects (or missing data objects). These data objects changed in 1.13 or 1.14. Here is a list of all non-legacy particle types with data (as declared by the Particle enum) in Spigot-API 1.14.4 (Bukkit is probably the same):
```java
REDSTONE(DustOptions.class),
ITEM_CRACK(ItemStack.class),
BLOCK_CRACK(BlockData.class),
BLOCK_DUST(BlockData.class),
FALLING_DUST(BlockData.class)
```
This pull request fixes the aforementioned trails by using these new data objects (DustOptions and BlockData).

It should be noted that there is no such thing anymore as the raw byte data of a MaterialData since Minecraft 1.13. As far as I know, all old material and data byte combinations are now fully fledged materials, apart from maybe some metadata as being waterlogged, which is now stored in BlockData objects. Hence I removed the support for data bytes (see BlockTrail and ItemTrail).

Since FALLING_DUST now requires block data and gunpowder is not a block, I had to change the FallingDust trail to use another material. Gravel made the most sense to me.

Finally, the single test always fails currently due to the following:

> java.lang.NullPointerException
> 	at org.bukkit.Bukkit.createBlockData(Bukkit.java:1354)
> 	at org.bukkit.Material.createBlockData(Material.java:3349)
> 	at ca.jamiesinn.trailgui.trails.BlockTrail.<init>(BlockTrail.java:15)
> 	at MaterialsTest.TestConfigMaterials(MaterialsTest.java:63)

Apparently creating BlockData requires a Server instance. Maybe this issue can be circumvented by creating the BlockData that is currently created in the constructor of BlockTrail, in `justDisplay` instead. What do you think?