### PR TITLE
Fix commands not running if no disabled worlds

### DIFF
--- a/src/main/java/ca/jamiesinn/trailgui/Listeners.java
+++ b/src/main/java/ca/jamiesinn/trailgui/Listeners.java
@@ -130,14 +130,9 @@ public class Listeners implements Listener
             return;
         }
 
-        for (String string : TrailGUI.disabledWorlds)
+        if (trailGUI.isWorldDisabled(player.getWorld().getName()))
         {
-            string = string.replace("[", "");
-            string = string.replace("]", "");
-            if (string.equals(player.getWorld().getName()))
-            {
-                return;
-            }
+            return;
         }
         List<Trail> trails = TrailGUI.enabledTrails.get(player.getUniqueId());
         try

--- a/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
+++ b/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
@@ -177,4 +177,18 @@ public class TrailGUI
     {
         return api;
     }
+
+    public boolean isWorldDisabled(String worldName)
+    {
+        for (String string : TrailGUI.disabledWorlds)
+        {
+            string = string.replace("[", "");
+            string = string.replace("]", "");
+            if (string.equals(worldName))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/ca/jamiesinn/trailgui/commands/CommandTrail.java
+++ b/src/main/java/ca/jamiesinn/trailgui/commands/CommandTrail.java
@@ -67,15 +67,10 @@ public class CommandTrail implements CommandExecutor, TabCompleter
             return true;
         }
         Player player = (Player) sender;
-        for (String string : TrailGUI.disabledWorlds)
+        if (trailGUI.isWorldDisabled(player.getWorld().getName()))
         {
-            string = string.replace("[", "");
-            string = string.replace("]", "");
-            if (string.equals(player.getWorld().getName()))
-            {
-                player.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "You cannot use this command in this world.");
-                return true;
-            }
+            player.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "You cannot use this command in this world.");
+            return true;
         }
 
         if (args.length == 0)

--- a/src/main/java/ca/jamiesinn/trailgui/commands/CommandTrailGUI.java
+++ b/src/main/java/ca/jamiesinn/trailgui/commands/CommandTrailGUI.java
@@ -20,47 +20,42 @@ public class CommandTrailGUI implements CommandExecutor
 
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args)
     {
-        for (String string : TrailGUI.disabledWorlds)
+        if (sender instanceof Player)
         {
-            string = string.replace("[", "");
-            string = string.replace("]", "");
-            if (sender instanceof Player)
+            Player player = (Player) sender;
+            if (trailGUI.isWorldDisabled(player.getWorld().getName()))
             {
-                Player player = (Player) sender;
-                if (string.equals(player.getWorld().getName()))
-                {
-                    player.sendMessage(TrailGUI.prefix + ChatColor.RED + "You cannot use this command in this world.");
-                    return true;
-                }
-            }
-            if (args.length == 0)
-            {
-                sender.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "Available commands:");
-                sender.sendMessage(ChatColor.GREEN + "/trailgui reload");
-                sender.sendMessage(ChatColor.GREEN + "/trailgui version");
+                player.sendMessage(TrailGUI.prefix + ChatColor.RED + "You cannot use this command in this world.");
                 return true;
             }
-            if (args[0].equalsIgnoreCase("reload"))
+        }
+        if (args.length == 0)
+        {
+            sender.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "Available commands:");
+            sender.sendMessage(ChatColor.GREEN + "/trailgui reload");
+            sender.sendMessage(ChatColor.GREEN + "/trailgui version");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("reload"))
+        {
+            if (!sender.hasPermission("trailgui.commands.reloadconfigs") && !sender.hasPermission("trailgui.*"))
             {
-                if (!sender.hasPermission("trailgui.commands.reloadconfigs") && !sender.hasPermission("trailgui.*"))
-                {
-                    sender.sendMessage(TrailGUI.getPlugin().getConfig().getString("Commands.denyPermissionMessage").replaceAll("&", "\u00A7"));
-                    return true;
-                }
-                Userdata.getInstance().reloadConfig();
-                Userdata.getInstance().saveConfig();
+                sender.sendMessage(TrailGUI.getPlugin().getConfig().getString("Commands.denyPermissionMessage").replaceAll("&", "\u00A7"));
+                return true;
+            }
+            Userdata.getInstance().reloadConfig();
+            Userdata.getInstance().saveConfig();
 
-                TrailGUI.getPlugin().reload();
+            TrailGUI.getPlugin().reload();
 
-                sender.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "Successfully reloaded all config files.");
-                return true;
-            }
-            if (args[0].equalsIgnoreCase("version"))
-            {
-                sender.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "Version: "
-                        + this.trailGUI.getDescription().getVersion());
-                return true;
-            }
+            sender.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "Successfully reloaded all config files.");
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("version"))
+        {
+            sender.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "Version: "
+                    + this.trailGUI.getDescription().getVersion());
+            return true;
         }
 
         return false;

--- a/src/main/java/ca/jamiesinn/trailgui/commands/CommandTrails.java
+++ b/src/main/java/ca/jamiesinn/trailgui/commands/CommandTrails.java
@@ -27,26 +27,22 @@ public class CommandTrails
             return true;
         }
         Player player = (Player) sender;
-        for (String string : TrailGUI.disabledWorlds)
+
+        if (trailGUI.isWorldDisabled(player.getWorld().getName()))
         {
-            string = string.replace("[", "");
-            string = string.replace("]", "");
-            if (string.equals(player.getWorld().getName()))
-            {
-                player.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "You cannot use this command in this world.");
-                return true;
-            }
-            if (!player.hasPermission("trailgui.commands.trails") && !player.hasPermission("trailgui.*"))
-            {
-                player.sendMessage(TrailGUI.getPlugin().getConfig().getString("Commands.denyPermissionMessage").replaceAll("&", "\u00A7"));
-                if (TrailGUI.getPlugin().getConfig().getBoolean("closeInventoryOnDenyPermission"))
-                {
-                    player.closeInventory();
-                }
-                return true;
-            }
-            Util.openGUI(player);
+            player.sendMessage(TrailGUI.prefix + ChatColor.GREEN + "You cannot use this command in this world.");
+            return true;
         }
+        if (!player.hasPermission("trailgui.commands.trails") && !player.hasPermission("trailgui.*"))
+        {
+            player.sendMessage(TrailGUI.getPlugin().getConfig().getString("Commands.denyPermissionMessage").replaceAll("&", "\u00A7"));
+            if (TrailGUI.getPlugin().getConfig().getBoolean("closeInventoryOnDenyPermission"))
+            {
+                player.closeInventory();
+            }
+            return true;
+        }
+        Util.openGUI(player);
         return false;
     }
 }


### PR DESCRIPTION
Currently the commands 'trailgui' and 'trails' don't work if there are *no* disabled worlds in the configuration file, because the implementations of both these commands are encased in giant for-loops that iterate over the disabled worlds. This pull requests fixes this. Since the is-world-disabled check is duplicated several times throughout the code base, I pulled it out into a separate method as well.