### PR TITLE
1.17 Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1346,7 +1346,7 @@ trails:
     #The items type.
     itemType: SOUL_SOIL
     #The items name.
-    itemName: "&Soul"
+    itemName: "&6Soul"
     #Whether or not the lore is enabled.
     loreEnabled: false
     glowEnabled: true
@@ -1354,6 +1354,351 @@ trails:
       - "Example"
       - "Line2"
       - "Line3"
+  DrippingDripstoneLava:
+    type: DRIPPING_DRIPSTONE_LAVA
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 56
+    #The items type.
+    itemType: lava_bucket
+    #The items name.
+    itemName: "&6DrippingDripstoneLava"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  DrippingDripstoneWater:
+    type: DRIPPING_DRIPSTONE_WATER
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 57
+    #The items type.
+    itemType: water_bucket
+    #The items name.
+    itemName: "&6DrippingDripstoneWater"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  ElectricSpark:
+    type: ELECTRIC_SPARK
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 58
+    #The items type.
+    itemType: lightning_rod
+    #The items name.
+    itemName: "&6ElectricSpark"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  FallingDripstoneLava:
+    type: FALLING_DRIPSTONE_LAVA
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 59
+    #The items type.
+    itemType: lava_bucket
+    #The items name.
+    itemName: "&6FallingDripstoneLava"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  FallingDripstoneWater:
+    type: FALLING_DRIPSTONE_WATER
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 60
+    #The items type.
+    itemType: water_bucket
+    #The items name.
+    itemName: "&6FallingDripstoneWater"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  FallingSporeBlossom:
+    type: FALLING_SPORE_BLOSSOM
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 61
+    #The items type.
+    itemType: spore_blossom
+    #The items name.
+    itemName: "&6FallingSporeBlossom"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  Glow:
+    type: GLOW
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 62
+    #The items type.
+    itemType: glow_ink_sac
+    #The items name.
+    itemName: "&6Glow"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  GlowSquidInk:
+    type: GLOW_SQUID_INK
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 0
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 63
+    #The items type.
+    itemType: glow_ink_sac
+    #The items name.
+    itemName: "&6GlowSquidInk"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3" 
+  Light:
+    type: LIGHT
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 64
+    #The items type.
+    itemType: glowstone
+    #The items name.
+    itemName: "&6Light"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"  
+  Scrape:
+    type: SCRAPE
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 65
+    #The items type.
+    itemType: iron_axe
+    #The items name.
+    itemName: "&6Scrape"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"    
+  SmallFlame:
+    type: SMALL_FLAME
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 66
+    #The items type.
+    itemType: candle
+    #The items name.
+    itemName: "&6SmallFlame"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"  
+  Snowflake:
+    type: SNOWFLAKE
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 67
+    #The items type.
+    itemType: snow
+    #The items name.
+    itemName: "&6Snowflake"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  SporeBlossomAir:
+    type: SPORE_BLOSSOM_AIR
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 68
+    #The items type.
+    itemType: spore_blossom
+    #The items name.
+    itemName: "&6SporeBlossomAir"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  WaxOff:
+    type: WAX_OFF
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 69
+    #The items type.
+    itemType: oxidized_copper
+    #The items name.
+    itemName: "&6WaxOff"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  WaxOn:
+    type: WAX_ON
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 70
+    #The items type.
+    itemType: copper_block
+    #The items name.
+    itemName: "&6WaxOn"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"         
 ############################################################
 # +------------------------------------------------------+ #
 # |          Configuration: Inventory Pagination   | #

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: ca.jamiesinn.trailgui.TrailGUI
 version: ${project.version}
 author: JamieSinn
 softdepend: [Essentials]
-api-version: 1.16
+api-version: 1.17
 
 commands:
    trail:
@@ -275,6 +275,51 @@ permissions:
    trailgui.trails.soul:
       description: Allows the player to select the specified trail.
       default: op
+   trailgui.trails.drippingdripstonelava:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.drippingdripstonewater:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.electricspark:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.fallingdripstonelava:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.drippingdripstonewater:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.fallingsporeblossom:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.glow:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.glowsquidink:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.light:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.scrape:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.smallflame:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.snowflake:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.sporeblossomair:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.waxoff:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.waxon:
+      description: Allows the player to select the specified trail.
+      default: op
 
    trailgui.commands.clearall:
       description: Allows the player to use the clearall trails command.
@@ -442,6 +487,51 @@ permissions:
    trailgui.trails.soul.other:
       description: Allows the player to select the specified trail.
       default: op
+   trailgui.trails.droppingdripstonelava.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.drippingdripstonewater.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.electricspark.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.fallingdripstonelava.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.fallingdripstonewater.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.fallingsporeblossom.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.glow.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.glowsquidink.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.light.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.scrape.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.smallflame.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.snowflake.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.sporeblossomair.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.waxoff.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.waxon.other:
+      description: Allows the player to select the specified trail.
+      default: op
 
    trailgui.commands.clearall.other:
       description: Allows the player to clear all of the specified players trails.
@@ -513,6 +603,22 @@ permissions:
                trailgui.trails.warpedspore: true
                trailgui.trails.soulfire: true
                trailgui.trails.soul: true
+               trailgui.trails.drippingdripstonelava: true
+               trailgui.trails.drippingdripstonewater: true
+               trailgui.trails.electricspark: true
+               trailgui.trails.fallingdripstonelava: true
+               trailgui.trails.fallingdripstonewater: true
+               trailgui.trails.fallingsporeblossom: true
+               trailgui.trails.glow: true
+               trailgui.trails.glowsquidink: true
+               trailgui.trails.light: true
+               trailgui.trails.scrape: true
+               trailgui.trails.smallflame: true
+               trailgui.trails.snowflake: true
+               trailgui.trails.sporeblossomair: true
+               trailgui.trails.waxoff: true
+               trailgui.trails.waxon: true
+               
                trailgui.trails.clearall: true
    trailgui.inventory.*:
       description: Allows the player to select all the trails in the GUI.
@@ -568,6 +674,22 @@ permissions:
             trailgui.trails.warpedspore: true
             trailgui.trails.soulfire: true
             trailgui.trails.soul: true
+            trailgui.trails.drippingdripstonelava: true
+            trailgui.trails.drippingdripstonewater: true
+            trailgui.trails.electricspark: true
+            trailgui.trails.fallingdripstonelava: true
+            trailgui.trails.fallingdripstonewater: true
+            trailgui.trails.fallingsporeblossom: true
+            trailgui.trails.glow: true
+            trailgui.trails.glowsquidink: true
+            trailgui.trails.light: true
+            trailgui.trails.scrape: true
+            trailgui.trails.smallflame: true
+            trailgui.trails.snowflake: true
+            trailgui.trails.sporeblossomair: true
+            trailgui.trails.waxoff: true
+            trailgui.trails.waxon: true
+            
             trailgui.inventory.clearall: true
             trailgui.inventory.nextpage: true
             trailgui.inventory.previouspage: true

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -1346,7 +1346,7 @@ trails:
     #The items type.
     itemType: SOUL_SOIL
     #The items name.
-    itemName: "&Soul"
+    itemName: "&6Soul"
     #Whether or not the lore is enabled.
     loreEnabled: false
     glowEnabled: true
@@ -1354,6 +1354,351 @@ trails:
       - "Example"
       - "Line2"
       - "Line3"
+  DrippingDripstoneLava:
+    type: DRIPPING_DRIPSTONE_LAVA
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 56
+    #The items type.
+    itemType: lava_bucket
+    #The items name.
+    itemName: "&6DrippingDripstoneLava"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  DrippingDripstoneWater:
+    type: DRIPPING_DRIPSTONE_WATER
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 57
+    #The items type.
+    itemType: water_bucket
+    #The items name.
+    itemName: "&6DrippingDripstoneWater"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  ElectricSpark:
+    type: ELECTRIC_SPARK
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 58
+    #The items type.
+    itemType: lightning_rod
+    #The items name.
+    itemName: "&6ElectricSpark"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  FallingDripstoneLava:
+    type: FALLING_DRIPSTONE_LAVA
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 59
+    #The items type.
+    itemType: lava_bucket
+    #The items name.
+    itemName: "&6FallingDripstoneLava"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  FallingDripstoneWater:
+    type: FALLING_DRIPSTONE_WATER
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 5
+    #The speed the particles are displayed.
+    speed: 0
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 60
+    #The items type.
+    itemType: water_bucket
+    #The items name.
+    itemName: "&6FallingDripstoneWater"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  FallingSporeBlossom:
+    type: FALLING_SPORE_BLOSSOM
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 61
+    #The items type.
+    itemType: spore_blossom
+    #The items name.
+    itemName: "&6FallingSporeBlossom"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  Glow:
+    type: GLOW
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 62
+    #The items type.
+    itemType: glow_ink_sac
+    #The items name.
+    itemName: "&6Glow"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  GlowSquidInk:
+    type: GLOW_SQUID_INK
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 0
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 63
+    #The items type.
+    itemType: glow_ink_sac
+    #The items name.
+    itemName: "&6GlowSquidInk"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3" 
+  Light:
+    type: LIGHT
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 64
+    #The items type.
+    itemType: glowstone
+    #The items name.
+    itemName: "&6Light"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"  
+  Scrape:
+    type: SCRAPE
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 65
+    #The items type.
+    itemType: iron_axe
+    #The items name.
+    itemName: "&6Scrape"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"    
+  SmallFlame:
+    type: SMALL_FLAME
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 66
+    #The items type.
+    itemType: candle
+    #The items name.
+    itemName: "&6SmallFlame"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"  
+  Snowflake:
+    type: SNOWFLAKE
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 67
+    #The items type.
+    itemType: snow
+    #The items name.
+    itemName: "&6Snowflake"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  SporeBlossomAir:
+    type: SPORE_BLOSSOM_AIR
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 68
+    #The items type.
+    itemType: spore_blossom
+    #The items name.
+    itemName: "&6SporeBlossomAir"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  WaxOff:
+    type: WAX_OFF
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 69
+    #The items type.
+    itemType: oxidized_copper
+    #The items name.
+    itemName: "&6WaxOff"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"   
+  WaxOn:
+    type: WAX_ON
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 10
+    #The speed the particles are displayed.
+    speed: 0.5
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 70
+    #The items type.
+    itemType: copper_block
+    #The items name.
+    itemName: "&6WaxOn"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"         
 ############################################################
 # +------------------------------------------------------+ #
 # |          Configuration: Inventory Pagination   | #


### PR DESCRIPTION
- [x] 1.17 trails: drippingdripstonelava, drippingdripstonewater, electricspark, fallingdripstonelava, drippingdripstonewater, fallingsporeblossom, glow, glowsquidink, light, scrape, smallflame, snowflake, sporeblossomair, waxoff, waxon.
- [x] Added permissions.
- [x] Update API version.
- [x] Update Spigot dependency.
- [x] Add a missing color code to the soul particles name.

There are some particles that require data such as vibration & dust color transition that were left out.