### PR TITLE
Update to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,6 @@
             <artifactId>spigot-api</artifactId>
             <version>1.19-R0.1-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.7</version>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
+++ b/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
@@ -7,14 +7,14 @@ import ca.jamiesinn.trailgui.commands.CommandTrails;
 import ca.jamiesinn.trailgui.files.Userdata;
 import ca.jamiesinn.trailgui.sql.SQLManager;
 import ca.jamiesinn.trailgui.trails.*;
-import org.apache.commons.io.FileUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -82,11 +82,11 @@ public class TrailGUI
         {
             getLogger().severe("Your config is out of date with the current one. Plugin will be disabled until it is corrected.");
             getLogger().severe("Copied the latest default config to the plugin directory for reference.");
-            URL inputUrl = getClass().getResource("config.yml");
             File dest = new File(getDataFolder(), "config.new.yml");
-            try
+            try (InputStream inputStream = getResource("config.yml"))
             {
-                FileUtils.copyURLToFile(inputUrl, dest);
+                dest.getParentFile().mkdirs();
+                Files.copy(inputStream, dest.toPath());
             }
             catch (IOException e)
             {

--- a/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
+++ b/src/main/java/ca/jamiesinn/trailgui/TrailGUI.java
@@ -143,6 +143,14 @@ public class TrailGUI
                         {
                             trailTypes.put(trailTypeSection.getName(), new EffectTrail(trailTypeSection));
                         }
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("SCULK_CHARGE"))
+                        {
+                            trailTypes.put(trailTypeSection.getName(), new SculkChargeTrail(trailTypeSection));
+                        }
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("SHRIEK"))
+                        {
+                            trailTypes.put(trailTypeSection.getName(), new ShriekTrail(trailTypeSection));
+                        }
                         else
                         {
                             trailTypes.put(trailTypeSection.getName(), new NormalTrail(trailTypeSection));

--- a/src/main/java/ca/jamiesinn/trailgui/trails/SculkChargeTrail.java
+++ b/src/main/java/ca/jamiesinn/trailgui/trails/SculkChargeTrail.java
@@ -1,0 +1,28 @@
+package ca.jamiesinn.trailgui.trails;
+
+import org.bukkit.Particle;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+public class SculkChargeTrail extends Trail
+{
+    public SculkChargeTrail(ConfigurationSection config)
+    {
+        super(config);
+        loadType(config.getString("type"));
+    }
+
+    @Override
+    protected void loadType(String sType)
+    {
+        this.type = Particle.valueOf(sType);
+    }
+
+    @Override
+    public void justDisplay(Player player)
+    {
+        if(!displayEvent(getName(), getDisplayLocation(), getAmount(), cooldown, getSpeed(), getRange(), type).isCancelled())
+            player.getWorld().spawnParticle(type, player.getLocation().add(0.0D, displayLocation, 0.0D), amount, 0,0,0, speed, (float) 0);
+    }
+}

--- a/src/main/java/ca/jamiesinn/trailgui/trails/ShriekTrail.java
+++ b/src/main/java/ca/jamiesinn/trailgui/trails/ShriekTrail.java
@@ -1,0 +1,27 @@
+package ca.jamiesinn.trailgui.trails;
+
+import org.bukkit.Particle;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+public class ShriekTrail extends Trail
+{
+    public ShriekTrail(ConfigurationSection config)
+    {
+        super(config);
+        loadType(config.getString("type"));
+    }
+
+    @Override
+    protected void loadType(String sType)
+    {
+        this.type = Particle.valueOf(sType);
+    }
+
+    @Override
+    public void justDisplay(Player player)
+    {
+        if(!displayEvent(getName(), getDisplayLocation(), getAmount(), cooldown, getSpeed(), getRange(), type).isCancelled())
+            player.getWorld().spawnParticle(type, player.getLocation().add(0.0D, displayLocation, 0.0D), amount, 0,0,0, speed, 0);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1491,7 +1491,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   Glow:
     type: GLOW
     #The location the particle effect is displayed.
@@ -1514,7 +1514,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   GlowSquidInk:
     type: GLOW_SQUID_INK
     #The location the particle effect is displayed.
@@ -1560,7 +1560,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"    
+      - "Line3"
   SmallFlame:
     type: SMALL_FLAME
     #The location the particle effect is displayed.
@@ -1583,7 +1583,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"  
+      - "Line3"
   Snowflake:
     type: SNOWFLAKE
     #The location the particle effect is displayed.
@@ -1629,7 +1629,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   WaxOff:
     type: WAX_OFF
     #The location the particle effect is displayed.
@@ -1652,7 +1652,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   WaxOn:
     type: WAX_ON
     #The location the particle effect is displayed.
@@ -1675,7 +1675,99 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"         
+      - "Line3"
+  SculkSoul:
+    type: SCULK_SOUL
+    #The location the particle effect is displayed.
+    displayLocation: 2
+    #The amount of particles displayed.
+    amount: 2
+    #The speed the particles are displayed.
+    speed: 0.25
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 70
+    #The items type.
+    itemType: sculk_vein
+    #The items name.
+    itemName: "&6SculkSoul"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  SculkCharge:
+    type: SCULK_CHARGE
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 3
+    #The speed the particles are displayed.
+    speed: 0.05
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 71
+    #The items type.
+    itemType: sculk
+    #The items name.
+    itemName: "&6SculkCharge"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  SculkChargePop:
+    type: SCULK_CHARGE_POP
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 3
+    #The speed the particles are displayed.
+    speed: 0.05
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 72
+    #The items type.
+    itemType: sculk
+    #The items name.
+    itemName: "&6SculkChargePop"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  Shriek:
+    type: SHRIEK
+    #The location the particle effect is displayed.
+    displayLocation: 2
+    #The amount of particles displayed.
+    amount: 1
+    #The speed the particles are displayed.
+    speed: 1
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 73
+    #The items type.
+    itemType: sculk_shrieker
+    #The items name.
+    itemName: "&6Shriek"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
 ############################################################
 # +------------------------------------------------------+ #
 # |          Configuration: Inventory Pagination   | #

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: ca.jamiesinn.trailgui.TrailGUI
 version: ${project.version}
 author: JamieSinn
 softdepend: [Essentials]
-api-version: 1.18
+api-version: 1.19
 
 commands:
    trail:
@@ -314,6 +314,18 @@ permissions:
    trailgui.trails.waxon:
       description: Allows the player to select the specified trail.
       default: op
+   trailgui.trails.sculksoul:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.sculkcharge:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.sculkchargepop:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.shriek:
+      description: Allows the player to select the specified trail.
+      default: op
 
    trailgui.commands.clearall:
       description: Allows the player to use the clearall trails command.
@@ -523,6 +535,19 @@ permissions:
    trailgui.trails.waxon.other:
       description: Allows the player to select the specified trail.
       default: op
+   trailgui.trails.sculksoul.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.sculkcharge.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.sculkchargepop.other:
+      description: Allows the player to select the specified trail.
+      default: op
+   trailgui.trails.shriek.other:
+      description: Allows the player to select the specified trail.
+      default: op
+
 
    trailgui.commands.clearall.other:
       description: Allows the player to clear all of the specified players trails.
@@ -608,7 +633,11 @@ permissions:
                trailgui.trails.sporeblossomair: true
                trailgui.trails.waxoff: true
                trailgui.trails.waxon: true
-               
+               trailgui.trails.sculksoul: true
+               trailgui.trails.sculkcharge: true
+               trailgui.trails.sculkchargepop: true
+               trailgui.trails.shriek: true
+
                trailgui.trails.clearall: true
    trailgui.inventory.*:
       description: Allows the player to select all the trails in the GUI.
@@ -678,7 +707,11 @@ permissions:
             trailgui.trails.sporeblossomair: true
             trailgui.trails.waxoff: true
             trailgui.trails.waxon: true
-            
+            trailgui.inventory.sculksoul: true
+            trailgui.inventory.sculkcharge: true
+            trailgui.inventory.sculkchargepop: true
+            trailgui.inventory.shriek: true
+
             trailgui.inventory.clearall: true
             trailgui.inventory.nextpage: true
             trailgui.inventory.previouspage: true

--- a/src/test/java/MaterialsTest.java
+++ b/src/test/java/MaterialsTest.java
@@ -69,6 +69,14 @@ public class MaterialsTest
                         {
                             trail = new EffectTrail(trailTypeSection);
                         }
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("SCULK_CHARGE"))
+                        {
+                            trail = new SculkChargeTrail(trailTypeSection);
+                        }
+                        else if (trailTypeSection.getString("type").equalsIgnoreCase("SHRIEK"))
+                        {
+                            trail = new ShriekTrail(trailTypeSection);
+                        }
                         else
                         {
                             trail = new NormalTrail(trailTypeSection);

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -1491,7 +1491,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   Glow:
     type: GLOW
     #The location the particle effect is displayed.
@@ -1514,7 +1514,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   GlowSquidInk:
     type: GLOW_SQUID_INK
     #The location the particle effect is displayed.
@@ -1560,7 +1560,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"    
+      - "Line3"
   SmallFlame:
     type: SMALL_FLAME
     #The location the particle effect is displayed.
@@ -1583,7 +1583,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"  
+      - "Line3"
   Snowflake:
     type: SNOWFLAKE
     #The location the particle effect is displayed.
@@ -1629,7 +1629,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   WaxOff:
     type: WAX_OFF
     #The location the particle effect is displayed.
@@ -1652,7 +1652,7 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"   
+      - "Line3"
   WaxOn:
     type: WAX_ON
     #The location the particle effect is displayed.
@@ -1675,7 +1675,99 @@ trails:
     lore:
       - "Example"
       - "Line2"
-      - "Line3"         
+      - "Line3"
+  SculkSoul:
+    type: SCULK_SOUL
+    #The location the particle effect is displayed.
+    displayLocation: 2
+    #The amount of particles displayed.
+    amount: 2
+    #The speed the particles are displayed.
+    speed: 0.25
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 70
+    #The items type.
+    itemType: sculk_vein
+    #The items name.
+    itemName: "&6SculkSoul"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  SculkCharge:
+    type: SCULK_CHARGE
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 3
+    #The speed the particles are displayed.
+    speed: 0.05
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 71
+    #The items type.
+    itemType: sculk
+    #The items name.
+    itemName: "&6SculkCharge"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  SculkChargePop:
+    type: SCULK_CHARGE_POP
+    #The location the particle effect is displayed.
+    displayLocation: 0.2
+    #The amount of particles displayed.
+    amount: 3
+    #The speed the particles are displayed.
+    speed: 0.05
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 72
+    #The items type.
+    itemType: sculk
+    #The items name.
+    itemName: "&6SculkChargePop"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
+  Shriek:
+    type: SHRIEK
+    #The location the particle effect is displayed.
+    displayLocation: 2
+    #The amount of particles displayed.
+    amount: 1
+    #The speed the particles are displayed.
+    speed: 1
+    #The distance before unrendering the particle effect.
+    range: 20
+    #The inventory slot the item is put in.
+    order: 73
+    #The items type.
+    itemType: sculk_shrieker
+    #The items name.
+    itemName: "&6Shriek"
+    #Whether or not the lore is enabled.
+    loreEnabled: false
+    glowEnabled: true
+    lore:
+      - "Example"
+      - "Line2"
+      - "Line3"
 ############################################################
 # +------------------------------------------------------+ #
 # |          Configuration: Inventory Pagination   | #


### PR DESCRIPTION
Added 4 new trails for 1.19: SculkSoul, SculkCharge, SculkChargePop and Shriek.

Currently this plugin depends on commons-io. However, in the future Spigot will no longer include commons-lang. I don't know whether this includes commons-io, but I thought I might as well get rid of that dependency. It's used to create a new config file if the current config file's version is out of date. This functionality was broken anyway, because this exception gets thrown:
```
[Server thread/ERROR]: [TrailGUI] Your config is out of date with the current one. Plugin will be disabled until it is corrected.
[Server thread/ERROR]: [TrailGUI] Copied the latest default config to the plugin directory for reference.
[Server thread/ERROR]: Error occurred while enabling TrailGUI v6.16.1 (Is it up to date?)
java.lang.NullPointerException: Cannot invoke "java.net.URL.openStream()" because "source" is null
        at org.apache.commons.io.FileUtils.copyURLToFile(FileUtils.java:1068) ~[commons-io-2.11.0.jar:2.11.0]
        at ca.jamiesinn.trailgui.TrailGUI.load(TrailGUI.java:89) ~[TrailGUI-6.16.1.jar:?]
        at ca.jamiesinn.trailgui.TrailGUI.onEnable(TrailGUI.java:69) ~[TrailGUI-6.16.1.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:536) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugin(CraftServer.java:554) ~[paper-1.19.jar:git-Paper-17]
        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugins(CraftServer.java:468) ~[paper-1.19.jar:git-Paper-17]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:633) ~[paper-1.19.jar:git-Paper-17]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:419) ~[paper-1.19.jar:git-Paper-17]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:306) ~[paper-1.19.jar:git-Paper-17]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1121) ~[paper-1.19.jar:git-Paper-17]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:302) ~[paper-1.19.jar:git-Paper-17]
        at java.lang.Thread.run(Thread.java:833) ~[?:?
```
This pull request fixes this issue as well.