### PR TITLE
Refresh GUI after clicking items

### DIFF
--- a/src/main/java/ca/jamiesinn/trailgui/Listeners.java
+++ b/src/main/java/ca/jamiesinn/trailgui/Listeners.java
@@ -56,6 +56,10 @@ public class Listeners implements Listener
             {
                 if (trail.onInventoryClick(player, event.getCurrentItem()))
                 {
+                    if (event.getView().getTopInventory().equals(player.getOpenInventory().getTopInventory()))
+                    {
+                        Util.openGUI(player, currentPage);
+                    }
                     return;
                 }
             }
@@ -97,6 +101,10 @@ public class Listeners implements Listener
                 if (TrailGUI.getPlugin().getConfig().getBoolean("GUI.closeInventoryAferSelect"))
                 {
                     player.closeInventory();
+                }
+                else
+                {
+                    Util.openGUI(player, currentPage);
                 }
             }
             else if (event.getCurrentItem().equals(Util.getItemNextPage()))

--- a/src/main/java/ca/jamiesinn/trailgui/trails/Trail.java
+++ b/src/main/java/ca/jamiesinn/trailgui/trails/Trail.java
@@ -158,6 +158,7 @@ public abstract class Trail
         {
             meta.setLore(lore);
         }
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
         item.setItemMeta(meta);
         return item;
     }
@@ -196,7 +197,7 @@ public abstract class Trail
     		meta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
     		currentItem.setItemMeta(meta);
     	}
-    	
+
         if (currentItem.equals(this.getItem()))
         {
             List<Trail> currentTrails = new ArrayList<Trail>();
@@ -205,7 +206,7 @@ public abstract class Trail
             {
                 currentTrails = TrailGUI.enabledTrails.get(player.getUniqueId());
             }
-            
+
             if (!canUseInventory(player))
             {
                 player.sendMessage(TrailGUI.getPlugin().getConfig().getString("GUI.denyPermissionMessage").replaceAll("&", "\u00A7"));
@@ -251,6 +252,7 @@ public abstract class Trail
                 {
                     player.closeInventory();
                 }
+                return true;
             }
 
         }


### PR DESCRIPTION
Currently when you click an item in the trails GUI, it doesn't apply the glint to show the item has been selected. Also, if you click on the "Remove Trails" button, it doesn't remove the glints from the items in the GUI. This pull request fixes these issues.

Items in the GUI such as swords have "When in main hand: 6 Attack Damage" in their lore. This pull request removes those kinds of things from the item lore by using the `HIDE_ATTRIBUTES` item flag.